### PR TITLE
Specify scheme in library.properties url value

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -5,5 +5,5 @@ maintainer==@micooke
 sentence=WWVB JJY transmitter
 paragraph=Designed for ATmega328p and ATmega32u4 based Arduino boards
 category=Other
-url=github.com/micooke/wwvb_jjy
+url=https://github.com/micooke/wwvb_jjy
 architectures=*


### PR DESCRIPTION
The library.properties url property is used by the Arduino IDE to add a clickable "More info" link to the Library Manager entry for each library. The scheme must be specified in order for this link to be clickable.